### PR TITLE
Migrate project to Room 3 (androidx.room3)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.room) apply false
+    alias(libs.plugins.room3) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ buildkonfigGradlePlugin = "0.17.1"
 structuredCoroutinesAnnotations = "0.5.0"
 
 androidx-room = "2.8.4"
+androidx-room3 = "3.0.0-alpha01"
 sqlite = "2.6.2"
 
 activity-compose = "1.13.0"
@@ -86,6 +87,8 @@ androidx-material3-adaptive = { module = "org.jetbrains.compose.material3.adapti
 
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidx-room" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidx-room" }
+androidx-room3-compiler = { group = "androidx.room3", name = "room3-compiler", version.ref = "androidx-room3" }
+androidx-room3-runtime = { group = "androidx.room3", name = "room3-runtime", version.ref = "androidx-room3" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 
 buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildkonfigGradlePlugin" }
@@ -102,3 +105,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeVersion" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "androidx-room" }
+room3 = { id = "androidx.room3", version.ref = "androidx-room3" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.room)
+    alias(libs.plugins.room3)
     id("com.codingfeline.buildkonfig")
 }
 
@@ -27,7 +27,6 @@ kotlin {
     }
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
     ).forEach {
@@ -69,7 +68,7 @@ kotlin {
             api(libs.koin.composeViewModel)
             api(libs.koin.compose.navigation3)
 
-            implementation(libs.androidx.room.runtime)
+            implementation(libs.androidx.room3.runtime)
             implementation(libs.sqlite.bundled)
 
             implementation(libs.androidx.nav3.ui)
@@ -126,13 +125,12 @@ android {
 dependencies {
     implementation(libs.androidx.core.animation)
     debugImplementation(libs.androidx.ui.tooling)
-    add("kspAndroid", libs.androidx.room.compiler)
-    add("kspIosX64", libs.androidx.room.compiler)
-    add("kspIosSimulatorArm64", libs.androidx.room.compiler)
-    add("kspIosArm64", libs.androidx.room.compiler)
+    add("kspAndroid", libs.androidx.room3.compiler)
+    add("kspIosSimulatorArm64", libs.androidx.room3.compiler)
+    add("kspIosArm64", libs.androidx.room3.compiler)
 }
 
-room {
+room3 {
     schemaDirectory("$projectDir/schemas")
 }
 

--- a/shared/src/androidMain/kotlin/com/santimattius/kmp/entertainment/core/db/database.android.kt
+++ b/shared/src/androidMain/kotlin/com/santimattius/kmp/entertainment/core/db/database.android.kt
@@ -1,18 +1,14 @@
 package com.santimattius.kmp.entertainment.core.db
 
 import android.content.Context
-import androidx.room.Room
-import androidx.room.RoomDatabase
-import com.santimattius.kmp.entertainment.core.db.TMDBDataBase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 
 actual class RoomFactory(private val context: Context) {
     actual fun create(): RoomDatabase.Builder<TMDBDataBase> {
         val appContext = context.applicationContext
-        val dbFile = appContext.getDatabasePath(DB_NAME)
-        return Room.databaseBuilder<TMDBDataBase>(
-            context = appContext,
-            name = dbFile.absolutePath
-        )
+        val dbPath = appContext.getDatabasePath(DB_NAME).absolutePath
+        return Room.databaseBuilder<TMDBDataBase>(context = appContext, name = dbPath)
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/FavoriteDao.kt
+++ b/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/FavoriteDao.kt
@@ -1,8 +1,8 @@
 package com.santimattius.kmp.entertainment.core.db
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.Query
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/FavoriteEntity.kt
+++ b/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/FavoriteEntity.kt
@@ -1,8 +1,8 @@
 package com.santimattius.kmp.entertainment.core.db
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity(tableName = "favorite")
 class FavoriteEntity(

--- a/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/TMDBDataBase.kt
+++ b/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/TMDBDataBase.kt
@@ -1,9 +1,9 @@
 package com.santimattius.kmp.entertainment.core.db
 
-import androidx.room.ConstructedBy
-import androidx.room.Database
-import androidx.room.RoomDatabase
-import androidx.room.RoomDatabaseConstructor
+import androidx.room3.ConstructedBy
+import androidx.room3.Database
+import androidx.room3.RoomDatabase
+import androidx.room3.RoomDatabaseConstructor
 
 interface DB {
     fun clearAllTables() {}
@@ -20,7 +20,7 @@ abstract class TMDBDataBase : RoomDatabase(), DB {
     }
 }
 
-// The Room compiler generates the `actual` implementations.
+// Room 3 compiler generates the `actual` implementations.
 @Suppress("NO_ACTUAL_FOR_EXPECT")
 expect object AppDatabaseConstructor : RoomDatabaseConstructor<TMDBDataBase> {
     override fun initialize(): TMDBDataBase

--- a/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/database.common.kt
+++ b/shared/src/commonMain/kotlin/com.santimattius.kmp.entertainment/core/db/database.common.kt
@@ -1,11 +1,10 @@
 package com.santimattius.kmp.entertainment.core.db
 
-import androidx.room.RoomDatabase
+import androidx.room3.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-
 
 expect class RoomFactory {
 

--- a/shared/src/iosMain/kotlin/com.santimattius.kmp.entertainment/core/db/database.ios.kt
+++ b/shared/src/iosMain/kotlin/com.santimattius.kmp.entertainment/core/db/database.ios.kt
@@ -1,7 +1,7 @@
 package com.santimattius.kmp.entertainment.core.db
 
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
@@ -9,10 +9,8 @@ import platform.Foundation.NSUserDomainMask
 
 actual class RoomFactory {
     actual fun create(): RoomDatabase.Builder<TMDBDataBase> {
-        val dbFilePath = documentDirectory()  + "/${DB_NAME}"
-        return Room.databaseBuilder<TMDBDataBase>(
-            name = dbFilePath,
-        )
+        val dbFilePath = documentDirectory() + "/$DB_NAME"
+        return Room.databaseBuilder<TMDBDataBase>(name = dbFilePath)
     }
 
     @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
Upgrade from androidx.room to the new androidx.room3 artifacts and plugin. Updated build files to add room3 dependencies and plugin aliases, switched KSP config to room3 compiler, and renamed the Gradle room block to room3. Source changes replace androidx.room imports with androidx.room3 across common, Android and iOS code, adjust database builder calls to use the resolved DB path, and update minor comments and targets (removed iosX64). This moves the project to Room 3 (3.0.0-alpha) while keeping database schema and KSP setup aligned with the new package.